### PR TITLE
Feature/setup reset confirmation

### DIFF
--- a/src/lib/play/Controls.svelte
+++ b/src/lib/play/Controls.svelte
@@ -68,27 +68,25 @@
    }
 
    function setup () {
-      if (!deckValid && $autoMulligan) return
+      if (!deckValid && $autoMulligan || !checkPrizesAndConfirm('setup')) return
 
-      if (checkPrizesAndConfirm('setup')) {
-         const mulligans = setupBoard()
-         if ($autoMulligan) showMessage(`${mulligans} Mulligans`)
+      const mulligans = setupBoard()
+      if ($autoMulligan) showMessage(`${mulligans} Mulligans`)
 
-         turn = 0
+      turn = 0
 
-         publishLog('Setup' + ($autoMulligan ? ` - ${mulligans} Mulligans` : ''))
-         shareBoardstate()
-      }
+      publishLog('Setup' + ($autoMulligan ? ` - ${mulligans} Mulligans` : ''))
+      shareBoardstate()
    }
 
    function reset () {
-      if(checkPrizesAndConfirm('reset')) {
-         resetBoard()
-         turn = 0
+      if (!checkPrizesAndConfirm('setup')) return
 
-         share('boardReset')
-         publishLog('Reset')
-      }
+      resetBoard()
+      turn = 0
+
+      share('boardReset')
+      publishLog('Reset')
    }
 
    function startTurn () {

--- a/src/lib/play/Controls.svelte
+++ b/src/lib/play/Controls.svelte
@@ -9,7 +9,7 @@
    import {
       cards, deck, hand, prizes, draw,
       vstarUsed, gxUsed, pokemonHidden,
-      reset as resetBoard,
+      reset as resetBoard, exportBoard,
       shareBoardstate
    } from '$lib/stores/player.js'
 
@@ -62,23 +62,33 @@
       draw7andPutPrizes()
    }
 
+   function checkPrizesAndConfirm(action) {
+      return !exportBoard().prizes.length || 
+         confirm(`You still have prizes remaining, are you sure you want to ${action}?`)
+   }
+
    function setup () {
       if (!deckValid && $autoMulligan) return
-      const mulligans = setupBoard()
-      if ($autoMulligan) showMessage(`${mulligans} Mulligans`)
 
-      turn = 0
+      if (checkPrizesAndConfirm('setup')) {
+         const mulligans = setupBoard()
+         if ($autoMulligan) showMessage(`${mulligans} Mulligans`)
 
-      publishLog('Setup' + ($autoMulligan ? ` - ${mulligans} Mulligans` : ''))
-      shareBoardstate()
+         turn = 0
+
+         publishLog('Setup' + ($autoMulligan ? ` - ${mulligans} Mulligans` : ''))
+         shareBoardstate()
+      }
    }
 
    function reset () {
-      resetBoard()
-      turn = 0
+      if(checkPrizesAndConfirm('reset')) {
+         resetBoard()
+         turn = 0
 
-      share('boardReset')
-      publishLog('Reset')
+         share('boardReset')
+         publishLog('Reset')
+      }
    }
 
    function startTurn () {

--- a/src/lib/play/Controls.svelte
+++ b/src/lib/play/Controls.svelte
@@ -80,7 +80,7 @@
    }
 
    function reset () {
-      if (!checkPrizesAndConfirm('setup')) return
+      if (!checkPrizesAndConfirm('reset')) return
 
       resetBoard()
       turn = 0


### PR DESCRIPTION
We had a game where someone accidentally clicked reset, and wasn't able to rewind board state.
This provides a simple confirmation for the two actions on the board that can cause board state wipe.