### PR TITLE
Adding ptcg api image handling for BG

### DIFF
--- a/src/lib/stores/oldCards.js
+++ b/src/lib/stores/oldCards.js
@@ -11,6 +11,7 @@ const retroSets = {
    N3: 'neo3',
    N4: 'neo4',
    E1: 'ecard1',
+   BG: 'bp',
    E2: 'ecard2',
    E3: 'ecard3',
    RS: 'ex1',


### PR DESCRIPTION
Cards from the Best of Game (BG) set currently show broken images, because the source of the image is e.g. https://limitlesstcg.nyc3.digitaloceanspaces.com/tpci/BG/BG_006_R_EN_XS.png instead of e.g. https://images.pokemontcg.io/bp/6.png . This PR should fix this